### PR TITLE
Issue6 webexception fix

### DIFF
--- a/USGS Water Data/USGS Water Data.cs
+++ b/USGS Water Data/USGS Water Data.cs
@@ -5,14 +5,13 @@ using System.Xml;
 using System.Text;
 using Microsoft.SqlServer.Server;
 using System.Data.SqlTypes;
-using System.Security.Cryptography.X509Certificates;
-using System.Net.Security;
 
 public partial class StoredProcedures
 {
     [Microsoft.SqlServer.Server.SqlProcedure]
     public static void UspGetUSGSDataBySite(SqlInt32 site)
     {
+        ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
         HttpWebRequest request =
             (HttpWebRequest)WebRequest.Create("https://waterservices.usgs.gov/nwis/iv/?format=waterml,2.0&indent=on&sites=" + site + "&siteStatus=all");
 
@@ -21,7 +20,6 @@ public partial class StoredProcedures
         request.ContentType = "application/xml";
         request.Accept = "application/xml";
 
-        ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
         using (HttpWebResponse response = (HttpWebResponse)request.GetResponse())
         {
             using (Stream receiveStream = response.GetResponseStream())


### PR DESCRIPTION
Frequently encountered following error:
System.Net.WebException: The request was aborted: Could not create SSL/TLS secure channel.

.Net version is 4.7.2.

Solution is to set ServicePointManager.SecurityProtocol SecurityProtocolType to TLS v1.2 prior to creating HttpWebRequest.

Closes #6 